### PR TITLE
Add custom length configuration

### DIFF
--- a/apps/api/v2/logic/secrets/generate_secret.rb
+++ b/apps/api/v2/logic/secrets/generate_secret.rb
@@ -8,7 +8,14 @@ module V2::Logic
 
       def process_secret
         @kind = :generate
-        @secret_value = Onetime::Utils.strand(12)
+        secret_opts = OT.conf.dig(:site, :secret_options) || {}
+        min_len = secret_opts[:min_password_length] || 8
+        max_len = secret_opts[:max_password_length] || 128
+
+        length = payload.fetch(:length, 12).to_i
+        length = min_len if length < min_len
+        length = max_len if length > max_len
+        @secret_value = Onetime::Utils.strand(length)
       end
 
     end

--- a/docs/api/definition.json
+++ b/docs/api/definition.json
@@ -1413,6 +1413,12 @@
                 "type": "string",
                 "pattern": "^[\\S]{8,64}$"
               },
+              "length": {
+                "type": "integer",
+                "minimum": 8,
+                "maximum": 128,
+                "default": 12
+              },
               "ttl": {
                 "oneOf": [
                   {

--- a/etc/config.example.yaml
+++ b/etc/config.example.yaml
@@ -94,6 +94,10 @@
     # These options will be presented to users when they create a new secret
     # Format: String of integers representing seconds
     :ttl_options: <%= (ENV['TTL_OPTIONS'] || nil) %>
+    # Minimum length for generated passwords
+    :min_password_length: <%= ENV['PASSWORD_MIN_LENGTH'] || 8 %>
+    # Maximum length for generated passwords
+    :max_password_length: <%= ENV['PASSWORD_MAX_LENGTH'] || 128 %>
   # Registration and Authentication settings
   :authentication:
     # Can be disabled altogether, including API authentication.

--- a/etc/config.schema.yaml
+++ b/etc/config.schema.yaml
@@ -39,6 +39,8 @@
   :secret_options:
     :default_ttl: any(str(), int())
     :ttl_options: str()
+    :min_password_length: any(str(), int())
+    :max_password_length: any(str(), int())
   :authentication:
     :enabled: any()
     :signup: any()

--- a/lib/onetime/config.rb
+++ b/lib/onetime/config.rb
@@ -27,7 +27,9 @@ module Onetime
               1.week,         # 604800
               2.weeks,        # 1209600
               30.days,        # 2592000
-            ]
+            ],
+            min_password_length: 8,
+            max_password_length: 128
           },
           interface: {
             ui: { enabled: true },
@@ -174,6 +176,16 @@ module Onetime
 
       if default_ttl.is_a?(String)
         conf[:site][:secret_options][:default_ttl] = default_ttl.to_i
+      end
+
+      min_len = conf.dig(:site, :secret_options, :min_password_length)
+      max_len = conf.dig(:site, :secret_options, :max_password_length)
+
+      if min_len.is_a?(String)
+        conf[:site][:secret_options][:min_password_length] = min_len.to_i
+      end
+      if max_len.is_a?(String)
+        conf[:site][:secret_options][:max_password_length] = max_len.to_i
       end
 
       # TODO: Move to an initializer

--- a/src/components/secrets/form/SecretForm.vue
+++ b/src/components/secrets/form/SecretForm.vue
@@ -18,6 +18,7 @@
   import { nanoid } from 'nanoid';
   import { computed, onMounted, ref, watch } from 'vue';
   import { useRouter } from 'vue-router';
+  import { WindowService } from '@/services/window.service';
 
   import CustomDomainPreview from './../../CustomDomainPreview.vue';
   import SecretContentInputArea from './SecretContentInputArea.vue';
@@ -48,6 +49,9 @@
   const productIdentity = useProductIdentity();
   const concealedMetadataStore = useConcealedMetadataStore();
   const showProTip = ref(props.withAsterisk);
+  const secretOptions = WindowService.get('secret_options');
+  const lengthMin = secretOptions?.min_password_length ?? 8;
+  const lengthMax = secretOptions?.max_password_length ?? 128;
 
   // Helper function to get validation errors
   const getError = (field: keyof typeof form) => validation.errors.get(field);
@@ -56,6 +60,8 @@
   const uniqueId = computed(() => `secret-form-${Math.random().toString(36).substring(2, 9)}`);
   const passphraseId = computed(() => `passphrase-${uniqueId.value}`);
   const passphraseErrorId = computed(() => `passphrase-error-${uniqueId.value}`);
+  const lengthId = computed(() => `length-${uniqueId.value}`);
+  const lengthErrorId = computed(() => `length-error-${uniqueId.value}`);
   const lifetimeId = computed(() => `lifetime-${uniqueId.value}`);
   const lifetimeErrorId = computed(() => `lifetime-error-${uniqueId.value}`);
   const recipientId = computed(() => `recipient-${uniqueId.value}`);
@@ -262,6 +268,39 @@
               aria-live="assertive"
               class="mt-1 text-sm font-medium text-red-600 dark:text-red-400">
               {{ getError('passphrase') }}
+            </div>
+
+            <!-- Password Length Field -->
+            <div class="relative">
+              <h3>
+                <label
+                  :for="lengthId"
+                  class="mb-1 block font-brand text-sm text-gray-600 dark:text-gray-300">
+                  {{ $t('web.COMMON.password_length') }}
+                </label>
+              </h3>
+              <div class="relative">
+                <input
+                  type="number"
+                  :value="form.length"
+                  :id="lengthId"
+                  name="length"
+                  :min="lengthMin"
+                  :max="lengthMax"
+                  :aria-invalid="!!getError('length')"
+                  :aria-errormessage="getError('length') ? lengthErrorId : undefined"
+                  :class="[cornerClass]"
+                  class="w-full border border-gray-200 bg-white py-2.5 pl-5 pr-10 text-sm text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-700 dark:bg-slate-800 dark:text-white dark:placeholder:text-gray-500"
+                  @input="(e) => operations.updateField('length', Number((e.target as HTMLInputElement).value))" />
+              </div>
+            </div>
+            <div
+              v-if="getError('length')"
+              :id="lengthErrorId"
+              role="alert"
+              aria-live="assertive"
+              class="mt-1 text-sm font-medium text-red-600 dark:text-red-400">
+              {{ getError('length') }}
             </div>
 
             <!-- Expiry Selection -->

--- a/src/composables/useSecretConcealer.ts
+++ b/src/composables/useSecretConcealer.ts
@@ -60,6 +60,7 @@ export function useSecretConcealer(options?: SecretConcealerOptions) {
     passphrase: form.passphrase,
     recipient: form.recipient,
     share_domain: form.share_domain,
+    length: form.length,
   });
 
   /**

--- a/src/composables/useSecretForm.ts
+++ b/src/composables/useSecretForm.ts
@@ -20,12 +20,17 @@ export interface SecretFormState {
 /**
  * Form validation schema
  */
+const secretOptions = WindowService.get('secret_options');
+const lengthMin = secretOptions?.min_password_length ?? 8;
+const lengthMax = secretOptions?.max_password_length ?? 128;
+
 const formSchema = z.object({
   secret: z.string().min(1, 'Secret content is required'),
   ttl: z.number().min(1, 'Expiration time is required'),
   passphrase: z.string(),
   recipient: transforms.fromString.optionalEmail,
   share_domain: z.string(),
+  length: z.number().min(lengthMin).max(lengthMax).optional(),
 });
 
 /**
@@ -46,6 +51,7 @@ function getDefaultFormState(): SecretFormData {
     passphrase: '',
     recipient: '',
     share_domain: '',
+    length: 12,
   };
 }
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -47,6 +47,7 @@
       "secret_privacy_options": "Privacy Options",
       "secret_passphrase": "Passphrase",
       "secret_passphrase_hint": "A word or phrase that's difficult to guess",
+      "password_length": "Password Length",
       "secret_recipient_address": "Recipient Address",
       "secret_placeholder": "Secret content goes here...",
       "header_create_account": "Create Account",

--- a/src/schemas/api/payloads/generate.ts
+++ b/src/schemas/api/payloads/generate.ts
@@ -12,6 +12,7 @@ import { baseSecretPayloadSchema } from './base';
 
 export const generatePayloadSchema = baseSecretPayloadSchema.extend({
   kind: z.literal('generate'),
+  length: z.number().min(8).max(128).optional(),
 });
 
 export type GeneratePayload = z.infer<typeof generatePayloadSchema>;

--- a/src/schemas/models/public.ts
+++ b/src/schemas/models/public.ts
@@ -39,6 +39,28 @@ export const secretOptionsSchema = z.object({
     .array(z.number().int().positive().min(60).max(2592000))
     .transform((arr) => arr.map((val) => transforms.fromString.number.parse(val)))
     .default([300, 1800, 3600, 14400, 43200, 86400, 259200, 604800, 1209600, 2592000]),
+
+  /**
+   * Minimum length allowed for generated passwords
+   * Default: 8
+   */
+  min_password_length: z
+    .number()
+    .int()
+    .positive()
+    .default(8)
+    .transform((val) => transforms.fromString.number.parse(val)),
+
+  /**
+   * Maximum length allowed for generated passwords
+   * Default: 128
+   */
+  max_password_length: z
+    .number()
+    .int()
+    .positive()
+    .default(128)
+    .transform((val) => transforms.fromString.number.parse(val)),
 });
 
 /**

--- a/tests/unit/ruby/config.test.yaml
+++ b/tests/unit/ruby/config.test.yaml
@@ -18,6 +18,8 @@
   :secret_options:
     :default_ttl: <%= ENV['DEFAULT_TTL'] || '43200' %> # 12 hours in seconds
     :ttl_options: <%= (ENV['TTL_OPTIONS'] || '1800 43200 604800') %> # 30m, 12h, 7d
+    :min_password_length: <%= ENV['PASSWORD_MIN_LENGTH'] || '8' %>
+    :max_password_length: <%= ENV['PASSWORD_MAX_LENGTH'] || '128' %>
   # Registration and Authentication settings
   :authentication:
     # Can be disabled altogether, including API authentication.


### PR DESCRIPTION
## Summary
- parameterize password length via new min/max config values
- read min/max in API and frontend logic
- document new config options and update OpenAPI schema

## Testing
- `pnpm lint`
- `pnpm test` *(fails: numerous unit tests require setup)*

------
https://chatgpt.com/codex/tasks/task_b_684848c586c8832990836ae26d7b8645